### PR TITLE
Added test for error case in `get`

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -151,4 +151,12 @@ module.exports = function (test, Store) {
     t.equal(store.chunkLength, 10)
     t.end()
   })
+
+  test('test `get` on non-existent index', function (t) {
+    var store = new Store(10)
+    store.get(0, function (err, chunk) {
+      t.ok(err instanceof Error)
+      t.end()
+    })
+  })
 }


### PR DESCRIPTION
If the index doesn't exist, then `get` should return an error.
This commit adds that test case.
